### PR TITLE
Allow vertical scrolling on body

### DIFF
--- a/true-composer-kit.html
+++ b/true-composer-kit.html
@@ -43,7 +43,8 @@
       min-height: 100vh;
       display: flex;
       flex-direction: column;
-      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
 
     h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
## Summary
- allow the document body to scroll vertically while keeping horizontal overflow hidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df85cdebec832991829691b62bf2cf